### PR TITLE
Adds onExit hook

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,8 @@ const defaultConf = {
   usePackageFile: true,
   writeHistoryFile: true,
   historyFileName: '.nc_history',
-  suggestParams: true
+  suggestParams: true,
+  onExit: false
 };
 
 const envConf = compact(

--- a/src/create-server.ts
+++ b/src/create-server.ts
@@ -12,7 +12,7 @@ export function isRecoverableError(error) {
 }
 
 export default function(prompt = name) {
-  return repl.start({
+    const server = repl.start({
     prompt,
     input: process.stdin,
     output: process.stdout,
@@ -34,4 +34,18 @@ export default function(prompt = name) {
       }
     }
   });
+  server.on('exit', () => {
+    let onExit = Config.config.onExit || (() => {/* */});
+    if (typeof onExit !== 'function') {
+        onExit = () => { console.error('The `onExit` hook is not a function!'); };
+    }
+    Promise.resolve(onExit())
+      .then(() => {
+        process.exit();
+      })
+      .catch(() => {
+        process.exit();
+      });
+  });
+  return server;
 }

--- a/src/test/config.test.ts
+++ b/src/test/config.test.ts
@@ -12,7 +12,8 @@ describe('Test config', function() {
         usePackageFile: true,
         writeHistoryFile: true,
         historyFileName: '.nc_history',
-        suggestParams: true
+        suggestParams: true,
+        onExit: false
       });
     });
   });
@@ -33,7 +34,8 @@ describe('Test config', function() {
         usePackageFile: true,
         writeHistoryFile: true,
         historyFileName: '.nc_history',
-        suggestParams: true
+        suggestParams: true,
+        onExit: false
       });
     });
   });


### PR DESCRIPTION
Sometimes we may add stuff to our `nc.js` that needs to be properly closed before exiting (ie database connection)

This PR adds an `onExit` hook that can be added via the `nc` Configuration and perform all those pre-exit cleanup tasks 